### PR TITLE
fix: support macOS in capture privilege check

### DIFF
--- a/src/leetha/cli.py
+++ b/src/leetha/cli.py
@@ -215,12 +215,19 @@ def _needs_capture(args: argparse.Namespace) -> bool:
 
 def _has_capture_privilege() -> bool:
     """Return True if the process can open a raw packet socket."""
-    try:
-        s = socket.socket(socket.AF_PACKET, socket.SOCK_RAW)
-        s.close()
+    if os.getuid() == 0:
         return True
-    except (PermissionError, OSError):
-        return False
+    if hasattr(socket, "AF_PACKET"):
+        # Linux: try opening a raw packet socket
+        try:
+            s = socket.socket(socket.AF_PACKET, socket.SOCK_RAW)
+            s.close()
+            return True
+        except (PermissionError, OSError):
+            return False
+    # macOS/BSD: check access to BPF device
+    import glob
+    return any(os.access(d, os.R_OK) for d in glob.glob("/dev/bpf*"))
 
 
 def _escalate_privileges():


### PR DESCRIPTION
## Summary

- `_has_capture_privilege()` in `cli.py` uses `socket.AF_PACKET` which is Linux-only and raises `AttributeError` on macOS
- Replaced with a platform-aware approach:
  1. Check `os.getuid() == 0` first (works on both Linux and macOS)
  2. Try `AF_PACKET` raw socket on Linux
  3. Fall back to checking `/dev/bpf*` device access on macOS/BSD

## Reproduce

On macOS:
```
sudo uv run leetha -i en0 --web
```

**Before fix:**
```
AttributeError: module 'socket' has no attribute 'AF_PACKET'
```

**After fix:** starts normally.

## Test plan

- [x] Verified on macOS (Darwin 25.4.0) — `leetha` starts and captures packets
- [ ] Linux behavior unchanged (AF_PACKET path preserved)